### PR TITLE
Fix 'o' selecting previous line

### DIFF
--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -166,7 +166,7 @@ define-command -hidden auto-pairs-insert-new-line %{ try %{
   # void main() {␤ → void main() {␤
   # }                }           ‾‾
   # ‾                ‾
-  auto-pairs-try-execute-keys '\Q${opener}\E\n\h*\Q${closer}\E' ';KGl'
+  auto-pairs-try-execute-keys '\Q${opener}\E\n\h*\Q${closer}\E' ';KGlL'
   # Insert a new line again
   execute-keys <up><end><ret>
 }}


### PR DESCRIPTION
The result of `;KGl`:

![image](https://user-images.githubusercontent.com/1177900/47531538-3468e980-d8ae-11e8-803d-261e36b4ace5.png)

The result of `;KGlL`:

![image](https://user-images.githubusercontent.com/1177900/47531583-5498a880-d8ae-11e8-95d8-944d77c89679.png)


Fixes #17 