### PR TITLE
Modify `auto-pairs-insert-new-line` implementation to remain consistent with associated comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ nestable characters (such as **apostrophes**), when preceded by word characters.
 
 Auto-pairing is also about pair navigation and editing (deleting existing pairs
 and formatting in pair).  It can move in pair `(▌)`, delete in pair `(▌)` and
-post pair `()▌`, and pad in pair horizontally `(␣▌␣)` and vertically `{⏎}`.
+post pair `()▌`, and pad in pair horizontally `(␣▌␣)` and vertically:
+```
+    …
+    foobar {
+        ▌
+    }
+    …
+```
+.
 
 When inserting an auto-paired character, if the opening and closing characters
 are the same (such as double quote strings), auto-pairs will move right in pair

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -158,9 +158,8 @@ provide-module auto-pairs %{
       # main() {
       #   ▌
       # }
-      execute-keys -with-hooks '<ret>'
-      execute-keys '<esc>'
-      execute-keys -with-hooks 'O'
+      execute-keys '<ret><ret><esc>KK<a-&>j<a-gt>A<esc>'
+      execute-keys -with-hooks 'i'
     } catch %{
       execute-keys -with-hooks '<ret>'
     }


### PR DESCRIPTION
The [comment right above the implementation](https://github.com/alexherbo2/auto-pairs.kak/blob/5b4b3b723c34c8b7f40cee60868204974349bf9f/rc/auto-pairs.kak#L158) shows behavior different than the actual:
> ```
>      # main() {
>      #   ▌
>      # }
> ```
This is the actual behavior:
```
      # main() {
      #   ▌
      #   }
```

This is described in #39.
> It looks to be the responsability of the [filetypes](https://github.com/mawww/kakoune/tree/master/rc/filetype) to produce a correct indenting when pressing Return.
> I’m afraid all filetypes are affected to not handle indenting in-between content, assuming new lines are inserted at the end of the line.

While I agree that this is valid reasoning, it's still annoying as hell to deal with the indentation.

> It is hard, because all filetypes are wrong. I feel like if I fix it in auto-pairs, upstream will never get fixed.

With this proposed implementation, it will still behave exactly the same even if/when upstream eventually gets fixed. Additionally, if you're averse to merging this to master, I would suggest creating a new branch. People can then use it if they get too fed up with the default filetypes behavior.