### PR TITLE
Revert auto-pairs-insert-new-line implementation to 5b4b3b7

### DIFF
--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -158,8 +158,9 @@ provide-module auto-pairs %{
       # main() {
       #   ▌
       # }
-      execute-keys '<ret><ret><esc>KK<a-&>j<a-gt>A<esc>'
-      execute-keys -with-hooks 'i'
+      execute-keys -with-hooks '<ret>'
+      execute-keys '<esc>'
+      execute-keys -with-hooks 'O'
     } catch %{
       execute-keys -with-hooks '<ret>'
     }


### PR DESCRIPTION
Because I fixed mawww/kakoune#3617 with the merged PR mawww/kakoune#3620, my previous changes to this repo are no longer needed.