### PR TITLE
Maintain append selection

### DIFF
--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -142,14 +142,16 @@ define-command -override -hidden handle-deleted-opening-pair -params 2 %{
 # {closing-pair} ⇒ Insert closing pair or move right in pair
 define-command -override -hidden insert-closing-pair-or-move-right-in-pair -params 1 %{
   try %{
+    # Succeeds if main selection's cursor lies on the current pair's closing character
     execute-keys -draft "<space>;<a-k>\Q%arg{1}<ret>"
-    # Move right in pair
-    execute-keys '<a-;>l'
+
+    # Remove closing pair to allow insertion
+    execute-keys '<del>'
     decrement-inserted-pairs-count
-  } catch %{
-    # Insert character with hooks
-    execute-keys -with-hooks %arg{1}
   }
+
+  # Insert character with hooks
+  execute-keys -with-hooks %arg{1}
 }
 
 # Enter ⇒ Insert a new indented line in pair (only for the next key)


### PR DESCRIPTION
Alters behavior of closing pair auto-insertion: instead of moving the selection to the right, we now use the delete key to remove the character under the cursor if it is the closing pair. The closing pair is now always inserted with hooks.

This has the side effect of preserving the selection when auto-closing during an insert that began with "append"

Asciinemas demonstrating the selection behavior:
- Original: https://asciinema.org/a/w61RTrnRJlvcVPXsoKTSFs3xs
- Branch: https://asciinema.org/a/4MgA15YC8Eqh33NLIcjATRc76