### PR TITLE
fix: support changed 'x' on master branch of kakoune

### DIFF
--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -163,7 +163,7 @@ define-command -override -hidden insert-new-line-in-pair %{
 define-command -override -hidden prompt-insert-new-line-in-pair %{
   prompt count: %{
     execute-keys '<a-;>;<ret><ret><esc>KK<a-&>j<a-gt>'
-    execute-keys "<a-x>Hy<a-x><a-d>%val{text}O<c-r>""<esc>"
+    execute-keys "xHyx<a-d>%val{text}O<c-r>""<esc>"
     execute-keys -with-hooks A
     reset-inserted-pairs-count
   }


### PR DESCRIPTION
The breaking-changes in the master branch of the Kakoune repo makes `x` work like `<a-x>`, and `<a-x>` work like `<a-X>`.
This should fix any issues and should probably be merged once the changes are added to the next release.