### PR TITLE
fix prompt-insert-new-line-in-pair

### DIFF
--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -163,7 +163,7 @@ define-command -override -hidden insert-new-line-in-pair %{
 define-command -override -hidden prompt-insert-new-line-in-pair %{
   prompt count: %{
     execute-keys '<a-;>;<ret><ret><esc>KK<a-&>j<a-gt>'
-    execute-keys "<a-x>Hy<a-x><a-d>%val{text}O<c-r>""<esc>"
+    execute-keys "xHyx<a-d>%val{text}O<c-r>""<esc>"
     execute-keys -with-hooks A
     reset-inserted-pairs-count
   }


### PR DESCRIPTION
<a-x> is now just x

== Kakoune 2022.10.31
* `x` now just extends the selection to contain full lines (as `<a-x>` did) `<a-x>` trims partial lines from the selection (as `<a-X>` did)