### PR TITLE
fix `handle-deleted-opening-pair` and `insert-closing-pair-or-move-right-in-pair`

### DIFF
--- a/docs/auto-pairs.asciidoc
+++ b/docs/auto-pairs.asciidoc
@@ -22,7 +22,7 @@ The script installs insert hooks on opening pair characters, such as brackets an
 
 When auto-closing has been triggered, it activates the following functionalities:
 
-- `closing-pair` ⇒ Insert character or move right in pair
+- `closing-pair` ⇒ Insert closing pair or move right in pair
 - `Enter` ⇒ Insert a new indented line in pair (only for the next key)
 - `Control+Enter` ⇒ Prompt a count for new indented lines in pair (only for the next key)
 

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -131,7 +131,7 @@ define-command -override -hidden handle-inserted-opening-pair -params 2 %{
 # Backspace ⇒ Erases the whole bracket
 define-command -override -hidden handle-deleted-opening-pair -params 2 %{
   try %{
-    execute-keys -draft "<space>;<a-k>\Q%arg{2}<ret>"
+    execute-keys -draft ",;<a-k>\Q%arg{2}<ret>"
     execute-keys '<del>'
     decrement-inserted-pairs-count
   }
@@ -142,7 +142,7 @@ define-command -override -hidden handle-deleted-opening-pair -params 2 %{
 # {closing-pair} ⇒ Insert closing pair or move right in pair
 define-command -override -hidden insert-closing-pair-or-move-right-in-pair -params 1 %{
   try %{
-    execute-keys -draft "<space>;<a-k>\Q%arg{1}<ret>"
+    execute-keys -draft ",;<a-k>\Q%arg{1}<ret>"
     # Move right in pair
     execute-keys '<a-;>l'
     decrement-inserted-pairs-count

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -51,7 +51,7 @@ declare-option -hidden int inserted_pairs
 # Retain inserted pairs
 remove-hooks global clean-auto-pairs-state
 hook -group clean-auto-pairs-state global WinSetOption 'inserted_pairs=0' %{
-  unmap window insert
+  trigger-user-hook auto-pairs-unmap-closers
   remove-hooks window auto-pairs
 }
 
@@ -78,6 +78,7 @@ define-command -override disable-auto-pairs -docstring 'disable auto-pairs' %{
 define-command -override -hidden auto-close-pair -params 2 %{
   hook -group auto-pairs global InsertChar "\Q%arg{1}" "handle-inserted-opening-pair %%<%arg{1}> %%<%arg{2}>"
   hook -group auto-pairs global InsertDelete "\Q%arg{1}" "handle-deleted-opening-pair %%<%arg{1}> %%<%arg{2}>"
+  hook -group auto-pairs global User auto-pairs-unmap-closers "unmap window insert %%<%arg{2}>"
 }
 
 # Internal hooks ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -99,9 +99,9 @@ define-command -override -hidden handle-inserted-opening-pair -params 2 %{
     }
 
     # Add insert mappings
-    map -docstring 'insert closing pair or move right in pair' window insert %arg{2} "<a-;>: insert-closing-pair-or-move-right-in-pair %%🐈%arg{2}🐈<ret>"
-    map -docstring 'insert a new indented line in pair' window insert <ret> '<a-;>: insert-new-line-in-pair<ret>'
-    map -docstring 'prompt a count for new indented lines in pair' window insert <c-ret> '<a-;>: prompt-insert-new-line-in-pair<ret>'
+    map -docstring 'insert closing pair or move right in pair' window insert %arg{2} "<a-;>:insert-closing-pair-or-move-right-in-pair %%🐈%arg{2}🐈<ret>"
+    map -docstring 'insert a new indented line in pair' window insert <ret> '<a-;>:insert-new-line-in-pair<ret>'
+    map -docstring 'prompt a count for new indented lines in pair' window insert <c-ret> '<a-;>:prompt-insert-new-line-in-pair<ret>'
 
     # Enter is only available on next key.
     hook -group auto-pairs -once window InsertChar '.*' %{

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -163,7 +163,7 @@ define-command -override -hidden insert-new-line-in-pair %{
 define-command -override -hidden prompt-insert-new-line-in-pair %{
   prompt count: %{
     execute-keys '<a-;>;<ret><ret><esc>KK<a-&>j<a-gt>'
-    execute-keys "<a-x>Hy<a-x><a-d>%val{text}O<c-r>""<esc>"
+    execute-keys "xHyx<a-d>%val{text}O<c-r>""<esc>"
     execute-keys -with-hooks A
     reset-inserted-pairs-count
   }

--- a/rc/auto-pairs.kak
+++ b/rc/auto-pairs.kak
@@ -41,12 +41,7 @@ declare-option -docstring 'list of surrounding pairs' str-list auto_pairs ( ) { 
 
 # Auto-pairing of characters activates only when this expression does not fail.
 # By default, it avoids non-nestable pairs (such as quotes), escaped pairs and word characters.
-declare-option -docstring 'auto-pairing of characters activates only when this expression does not fail' str auto_close_trigger %{
-  execute-keys '<a-h>'
-  execute-keys '<a-K>(\w["''`]|""|''''|``).\z<ret>'
-  set-register / "[^\\]?\Q%opt{opening_pair}\E\W\z"
-  execute-keys '<a-k><ret>'
-}
+declare-option -docstring 'auto-pairing of characters activates only when this expression does not fail' str auto_close_trigger '<a-h><a-K>(\w["''`]|""|''''|``).\z<ret><a-k>[^\\]?\Q%opt{opening_pair}<a-!>\E\W\z<ret>'
 
 # Internal variables ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 
@@ -93,7 +88,7 @@ define-command -override -hidden handle-inserted-opening-pair -params 2 %{
     # If not, it will throw an exception and execution will jump to
     # the “catch” block below.
     set-option window opening_pair %arg{1}
-    evaluate-commands -draft -save-regs '/' %opt{auto_close_trigger}
+    execute-keys -draft %opt{auto_close_trigger}
 
     # Action: Close pair
     execute-keys %arg{2}


### PR DESCRIPTION
kak 2022.10.31 swaps `<space>` and `,`